### PR TITLE
Fix issue with personalized link and PostgreSQL.

### DIFF
--- a/database/migrations/2017_10_26_183428_install.php
+++ b/database/migrations/2017_10_26_183428_install.php
@@ -17,7 +17,7 @@ class Install extends Migration
         Schema::defaultStringLength(191);
 
         Schema::create('polls', function (Blueprint $table) {
-            $table->char('id', 16);
+            $table->string('id', 16);
             $table->char('admin_id', 24);
             $table->text('title');
             $table->text('description')->nullable();;


### PR DESCRIPTION
In the `polls` table, when we create a poll with a customized link,
the database stored extra spaces at the end.
But the `poll_id` foreign key in others tables don't store these extra spaces!

Here an example of what was stored in the `id` column of the `polls` table:
```
"my-poll-name   "
-------------^
```

NB: I don't know if MySQL had the same issue...